### PR TITLE
Implement repair function for OpenStack cloud provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,7 +231,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c6ae6215aaacaa06d48c8cd231a6c28396b8f3a1efea1ebb0b3563062e4ef26a"
+  digest = "1:8a5e9ae8b975657a3aa1bc913bbe43a317667e4eff3126ce316053e41a13dc9a"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -245,10 +245,12 @@
     "openstack/common/extensions",
     "openstack/compute/v2/extensions/attachinterfaces",
     "openstack/compute/v2/extensions/availabilityzones",
+    "openstack/compute/v2/extensions/startstop",
     "openstack/compute/v2/extensions/volumeattach",
     "openstack/compute/v2/flavors",
     "openstack/compute/v2/images",
     "openstack/compute/v2/servers",
+    "openstack/containerinfra/v1/clusters",
     "openstack/identity/v2/tenants",
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/extensions/trusts",
@@ -269,6 +271,8 @@
     "openstack/networking/v2/networks",
     "openstack/networking/v2/ports",
     "openstack/networking/v2/subnets",
+    "openstack/orchestration/v1/stackresources",
+    "openstack/orchestration/v1/stacks",
     "openstack/sharedfilesystems/apiversions",
     "openstack/sharedfilesystems/v2/shares",
     "openstack/utils",
@@ -277,7 +281,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "2c55d17f707cc8333ca4f49690cb2970d12a25f6"
+  revision = "e87e5f90e7e67a309e0fe96dac144b824447607f"
 
 [[projects]]
   branch = "master"
@@ -591,6 +595,14 @@
   ]
   pruneopts = "UT"
   revision = "d0f344d83b0c80a1bc03b547a2374a9ec6711144"
+
+[[projects]]
+  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:e4c72127d910a96daf869a44f3dd563b86dbe6931a172863a0e99c5ff04b59e4"
@@ -1546,8 +1558,10 @@
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
+    "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
+    "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
     "github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets",
@@ -1566,6 +1580,8 @@
     "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
+    "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources",
+    "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares",
     "github.com/gophercloud/gophercloud/openstack/utils",
@@ -1581,6 +1597,7 @@
     "github.com/onsi/gomega",
     "github.com/pborman/uuid",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/satori/go.uuid",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",

--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -17,35 +17,153 @@ limitations under the License.
 package openstack
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/gophercloud/gophercloud"
 
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop"
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+	uuid "github.com/satori/go.uuid"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/healthcheck"
+	"k8s.io/klog"
 )
 
 const (
-	ProviderName = "openstack"
+	ProviderName                  = "openstack"
+	clusterStatusUpdateInProgress = "UPDATE_IN_PROGRESS"
+	clusterStatusUpdateComplete   = "UPDATE_COMPLETE"
+	clusterStatusUpdateFailed     = "UPDATE_FAILED"
+	stackStatusUpdateFailed       = "UPDATE_FAILED"
+	stackStatusUpdateInProgress   = "UPDATE_IN_PROGRESS"
+	stackStatusUpdateComplete     = "UPDATE_COMPLETE"
+)
+
+var statusesPreventingRepair = sets.NewString(
+	stackStatusUpdateInProgress,
+	stackStatusUpdateFailed,
 )
 
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
 type OpenStackCloudProvider struct {
-	Nova   *gophercloud.ServiceClient
-	Heat   *gophercloud.ServiceClient
-	Magnum *gophercloud.ServiceClient
-	Config config.Config
+	Nova                 *gophercloud.ServiceClient
+	Heat                 *gophercloud.ServiceClient
+	Magnum               *gophercloud.ServiceClient
+	Config               config.Config
+	ResourceStackMapping map[string]ResourceStackRelationship
+}
+
+type ResourceStackRelationship struct {
+	ResourceID   string
+	ResourceName string
+	StackID      string
+	StackName    string
 }
 
 func (provider OpenStackCloudProvider) GetName() string {
 	return ProviderName
 }
 
+// getStackName finds the name of a stack matching a given ID.
+func (provider *OpenStackCloudProvider) getStackName(stackID string) (string, error) {
+	stack, err := stacks.Find(provider.Heat, stackID).Extract()
+	if err != nil {
+		return "", fmt.Errorf("Could not find stack with ID %s: %v", stackID, err)
+	}
+	klog.V(0).Infof("For stack ID %s, stack name is %s", stackID, stack.Name)
+	return stack.Name, nil
+}
+
+// getAllStackResourceMapping returns all mapping relationships including
+// masters and minions(workers). The key in the map is the server/instance ID
+// in Nova and the value is the resource ID and name of the server, and the
+// parent stack ID and name.
+func (provider *OpenStackCloudProvider) getAllStackResourceMapping(stackName, stackID string) (m map[string]ResourceStackRelationship, err error) {
+	if provider.ResourceStackMapping != nil {
+		return provider.ResourceStackMapping, nil
+	}
+	mapping := make(map[string]ResourceStackRelationship)
+	stackPages, err := stacks.List(provider.Heat, stacks.ListOpts{ShowNested: true}).AllPages()
+	if err != nil {
+		return m, fmt.Errorf("Could not list stacks: %v", err)
+	}
+	allStacks, err := stacks.ExtractStacks(stackPages)
+
+	serverPages, err := stackresources.List(provider.Heat, stackName, stackID, stackresources.ListOpts{Depth: 2}).AllPages()
+	if err != nil {
+		return m, fmt.Errorf("Could not list servers pages of given stack resource: %v", err)
+	}
+	serverResources, err := stackresources.ExtractResources(serverPages)
+	if err != nil {
+		return m, fmt.Errorf("Could not list servers resource: %v", err)
+	}
+	for _, sr := range serverResources {
+		if sr.Type != "OS::Nova::Server" {
+			continue
+		}
+		for _, sp := range allStacks {
+			matched, err := regexp.MatchString(stackName+`-(kube_masters|kube_minions)-\S+-\d+-\S+$`, sp.Name)
+			if err != nil {
+				klog.Warningln("Failed to find matched stack for %s", sp.Name)
+			}
+			if matched && strings.Contains(sr.Links[0].Href, sp.Name) {
+				m := ResourceStackRelationship{
+					ResourceID:   sr.PhysicalID,
+					ResourceName: sr.Name,
+					StackID:      sp.ID,
+					StackName:    sp.Name,
+				}
+				klog.V(8).Infof("Resource ID: %s, Resource name: %s, Parent ID: %s, Parent name: %s", sr.PhysicalID, sr.Name, sp.ID, sp.Name)
+				mapping[sr.PhysicalID] = m
+			}
+		}
+	}
+	provider.ResourceStackMapping = mapping
+	return provider.ResourceStackMapping, nil
+}
+
 // Repair soft deletes the VMs, marks the heat resource "unhealthy" then trigger Heat stack update in order to rebuild
 // the VMs. The information this function needs:
 // - Nova VM IDs
 // - Heat stack ID and resource ID.
-func (provider OpenStackCloudProvider) Repair([]healthcheck.NodeInfo) error {
+func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) error {
 	// Get Heat stack ID related to the Magnum cluster.
+	cluster, err := clusters.Get(provider.Magnum, provider.Config.ClusterName).Extract()
+	clusterStackName, err := provider.getStackName(cluster.StackID)
+	allMapping, err := provider.getAllStackResourceMapping(clusterStackName, cluster.StackID)
 
+	for _, n := range nodes {
+		id, err := uuid.FromString(n.KubeNode.Status.NodeInfo.MachineID)
+		if err != nil {
+			klog.Warningln("Failed to get the correct server ID for server %s.", n.KubeNode.Name)
+			continue
+		}
+		serverID := id.String()
+		err = startstop.Stop(provider.Nova, serverID).ExtractErr()
+		if err != nil {
+			klog.Warningln("Failed to shutdown server server %s.", serverID)
+		}
+		klog.V(0).Infof("Marking unhealthy on node %s", serverID)
+		opts := stackresources.MarkUnhealthyOpts{
+			MarkUnhealthy:        true,
+			ResourceStatusReason: "Mark resource unhealthy by autohealing controller",
+		}
+		err = stackresources.MarkUnhealthy(provider.Heat, allMapping[serverID].StackName, allMapping[serverID].StackID, allMapping[serverID].ResourceID, opts).ExtractErr()
+		if err != nil {
+			klog.Errorf("Failed to mark resource %s unhealthy", serverID)
+		}
+	}
+
+	err = stacks.Update(provider.Heat, clusterStackName, cluster.StackID, nil).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Could not update stack to rebuild resources: %v", err)
+	}
 	return nil
 }
 
@@ -54,5 +172,26 @@ func (provider OpenStackCloudProvider) Repair([]healthcheck.NodeInfo) error {
 // - The cluster admin disables the auto healing via OpenStack API.
 // - The Magnum cluster is not in stable status.
 func (provider OpenStackCloudProvider) Enabled() bool {
+	cluster, err := clusters.Get(provider.Magnum, provider.Config.ClusterName).Extract()
+	autoHealingEnabled, err := strconv.ParseBool(cluster.Labels["auto_healing_enabled"])
+	if err != nil {
+		klog.Warningln("Failed to get the auto_healing_enabled label from cluster.")
+		return false
+	}
+	if !autoHealingEnabled {
+		klog.V(0).Infoln("Auto healing on current cluster is disabled.")
+		return false
+	}
+
+	clusterStackName, err := provider.getStackName(cluster.StackID)
+	stack, err := stacks.Get(provider.Heat, clusterStackName, cluster.StackID).Extract()
+	if err != nil {
+		klog.Warningln("Failed to get stack %s", cluster.StackID)
+	}
+	if statusesPreventingRepair.Has(stack.Status) {
+		klog.V(0).Infoln("Current stack is in status %s", stack.Status)
+		return false
+	}
+
 	return true
 }


### PR DESCRIPTION
Implement the repair function for OpenStack cloud provider. A mapping between node resources and stacks are built which can be used to find the stack name and ID to call Heat mark unhealthy function. Then call Heat stack update to get the resources replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lingxiankong/cloud-provider-openstack/1)
<!-- Reviewable:end -->
